### PR TITLE
Docs: Update docs and snippets to use 'default' keyword instead of 'normal'.

### DIFF
--- a/docs/_snippets/features/custom-font-size-named-options.js
+++ b/docs/_snippets/features/custom-font-size-named-options.js
@@ -19,7 +19,7 @@ ClassicEditor
 		fontSize: {
 			options: [
 				'small',
-				'normal',
+				'default',
 				'big'
 			]
 		}

--- a/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -21,7 +21,7 @@ ClassicEditor
 				9,
 				11,
 				13,
-				'normal',
+				'default',
 				17,
 				19,
 				21

--- a/docs/features/font.md
+++ b/docs/features/font.md
@@ -47,7 +47,7 @@ It is possible to configure which font size options are supported by the editor.
 
 Use the special `'default'` keyword to use the default font size defined in the web page styles. It removes any custom font size.
 
-The font size feature supports two ways of defining the configuration: using  predefined (named) presets or simple numeric values.
+The font size feature supports two ways of defining the configuration: using predefined (named) presets or simple numeric values.
 
 ### Using the predefined presets
 

--- a/docs/features/font.md
+++ b/docs/features/font.md
@@ -45,7 +45,7 @@ ClassicEditor
 
 It is possible to configure which font size options are supported by the editor. Use the {@link module:font/fontsize~FontSizeConfig#options `fontSize.options`} configuration option to do so.
 
-Use the special `'normal'` keyword to use the default font size defined in the web page styles. It removes any custom font size.
+Use the special `'default'` keyword to use the default font size defined in the web page styles. It removes any custom font size.
 
 The font size feature supports two ways of defining the configuration: using  predefined (named) presets or simple numeric values.
 
@@ -94,7 +94,7 @@ ClassicEditor
 		fontSize: {
 			options: [
 				'tiny',
-				'normal',
+				'default',
 				'big'
 			]
 		},
@@ -119,7 +119,7 @@ For example, `14` will be represented in the editor data as:
 <span style="font-size: 14px">...</span>
 ```
 
-Here is an example of the editor that supports numerical font sizes. Note that `'normal'` is controlled by the default styles of the web page:
+Here is an example of the editor that supports numerical font sizes. Note that `'default'` is controlled by the default styles of the web page:
 
 ```js
 ClassicEditor
@@ -129,7 +129,7 @@ ClassicEditor
 				9,
 				11,
 				13,
-				'normal',
+				'default',
 				17,
 				19,
 				21


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Update docs and snippets to use 'default' keyword instead of 'normal'.

---

### Additional information

* I did not put the 'normal' into "using predefined presets" as it doesn't fit there for me.
