### PR TITLE
Remove Positon, Range, Selection imports from engine/model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.0.1",
-    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-utils": "^11.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-cloud-services": "^10.1.0",
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
+    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-highlight": "^10.0.3",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
     "eslint": "^5.5.0",

--- a/tests/fontcommand.js
+++ b/tests/fontcommand.js
@@ -8,8 +8,6 @@ import FontCommand from '../src/fontcommand';
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 
 describe( 'FontCommand', () => {
 	let editor, model, doc, root, command;
@@ -172,10 +170,10 @@ describe( 'FontCommand', () => {
 
 			model.change( writer => {
 				// Simulate clicking right arrow key by changing selection ranges.
-				writer.setSelection( [ new Range( new Position( root, [ 0, 2 ] ), new Position( root, [ 0, 2 ] ) ) ] );
+				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 2 ) ) ] );
 
 				// Get back to previous selection.
-				writer.setSelection( [ new Range( new Position( root, [ 0, 1 ] ), new Position( root, [ 0, 1 ] ) ) ] );
+				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 1 ) ) ] );
 			} );
 
 			expect( command.value ).to.be.undefined;
@@ -194,14 +192,14 @@ describe( 'FontCommand', () => {
 			// Attribute should be stored.
 			// Simulate clicking somewhere else in the editor.
 			model.change( writer => {
-				writer.setSelection( [ new Range( new Position( root, [ 0, 2 ] ), new Position( root, [ 0, 2 ] ) ) ] );
+				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 2 ) ) ] );
 			} );
 
 			expect( command.value ).to.be.undefined;
 
 			// Go back to where attribute was stored.
 			model.change( writer => {
-				writer.setSelection( [ new Range( new Position( root, [ 1, 0 ] ), new Position( root, [ 1, 0 ] ) ) ] );
+				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 1 ] ), 0 ) ) ] );
 			} );
 
 			// Attribute should be restored.

--- a/tests/fontcommand.js
+++ b/tests/fontcommand.js
@@ -170,10 +170,10 @@ describe( 'FontCommand', () => {
 
 			model.change( writer => {
 				// Simulate clicking right arrow key by changing selection ranges.
-				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 2 ) ) ] );
+				writer.setSelection( root.getNodeByPath( [ 0 ] ), 2 );
 
 				// Get back to previous selection.
-				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 1 ) ) ] );
+				writer.setSelection( root.getNodeByPath( [ 0 ] ), 1 );
 			} );
 
 			expect( command.value ).to.be.undefined;
@@ -192,14 +192,14 @@ describe( 'FontCommand', () => {
 			// Attribute should be stored.
 			// Simulate clicking somewhere else in the editor.
 			model.change( writer => {
-				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 0 ] ), 2 ) ) ] );
+				writer.setSelection( root.getNodeByPath( [ 0 ] ), 2 );
 			} );
 
 			expect( command.value ).to.be.undefined;
 
 			// Go back to where attribute was stored.
 			model.change( writer => {
-				writer.setSelection( [ writer.createRange( writer.createPositionAt( root.getNodeByPath( [ 1 ] ), 0 ) ) ] );
+				writer.setSelection( root.getNodeByPath( [ 1 ] ), 0 );
 			} );
 
 			// Attribute should be restored.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
