### PR TITLE
t/ckeditor5/1348: Used the getViewportTopOffsetConfig helper in the code snippets.

### DIFF
--- a/docs/_snippets/features/custom-font-family-options.js
+++ b/docs/_snippets/features/custom-font-family-options.js
@@ -13,7 +13,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'fontFamily', 'bulletedList', 'numberedList', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		fontFamily: {
 			options: [

--- a/docs/_snippets/features/custom-font-size-named-options.js
+++ b/docs/_snippets/features/custom-font-size-named-options.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'fontSize', 'bulletedList', 'numberedList', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		fontSize: {
 			options: [

--- a/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'fontSize', 'bulletedList', 'numberedList', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		fontSize: {
 			options: [

--- a/docs/_snippets/features/font.js
+++ b/docs/_snippets/features/font.js
@@ -14,7 +14,7 @@ ClassicEditor
 			items: [
 				'heading', '|', 'fontSize', 'fontFamily', '|', 'bulletedList', 'numberedList', 'undo', 'redo'
 			],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		}
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the `getViewportTopOffsetConfig` helper in the code snippets to make sure the toolbar top offset is correct regardless of the page layout (see ckeditor/ckeditor5#1348).

---

### Additional information

This PR is a piece of the https://github.com/ckeditor/ckeditor5/pull/1360 constellation.
