### PR TITLE
Marked font size and font family attributes with the AttributeProperties#isFormatting property

### DIFF
--- a/src/fontfamily/fontfamilyediting.js
+++ b/src/fontfamily/fontfamilyediting.js
@@ -56,6 +56,7 @@ export default class FontFamilyEditing extends Plugin {
 
 		// Allow fontFamily attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_FAMILY } );
+		editor.model.schema.setAttributeProperties( FONT_FAMILY, { isFormatting: true } );
 
 		// Get configured font family options without "default" option.
 		const options = normalizeOptions( editor.config.get( 'fontFamily.options' ) ).filter( item => item.model );

--- a/src/fontsize/fontsizeediting.js
+++ b/src/fontsize/fontsizeediting.js
@@ -65,5 +65,6 @@ export default class FontSizeEditing extends Plugin {
 
 		// Allow fontSize attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_SIZE } );
+		editor.model.schema.setAttributeProperties( FONT_SIZE, { isFormatting: true } );
 	}
 }

--- a/tests/fontfamily/fontfamilyediting.js
+++ b/tests/fontfamily/fontfamilyediting.js
@@ -36,6 +36,12 @@ describe( 'FontFamilyEditing', () => {
 		expect( editor.model.schema.checkAttribute( [ '$block' ], 'fontFamily' ) ).to.be.false;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontFamily' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'config', () => {
 		describe( 'default value', () => {
 			it( 'should be set', () => {

--- a/tests/fontsize/fontsizeediting.js
+++ b/tests/fontsize/fontsizeediting.js
@@ -36,6 +36,12 @@ describe( 'FontSizeEditing', () => {
 		expect( editor.model.schema.checkAttribute( [ '$block' ], 'fontSize' ) ).to.be.false;
 	} );
 
+	it( 'should be marked with a formatting property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontSize' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'config', () => {
 		describe( 'default value', () => {
 			it( 'should be set', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Marked font size and font family as a formatting attribute using the `AttributeProperties#isFormatting` property. Closes ckeditor/ckeditor5#1664.

---

### Additional information

There are 2 more pull requests related with this in respective repositories.

All The PRs are referenced in ckeditor/ckeditor5#1664.