### PR TITLE
Marked font color and background color as formatting attribute using the isFormatting property

### DIFF
--- a/src/fontbackgroundcolor/fontbackgroundcolorediting.js
+++ b/src/fontbackgroundcolor/fontbackgroundcolorediting.js
@@ -117,5 +117,7 @@ export default class FontBackgroundColorEditing extends Plugin {
 
 		// Allow fontBackgroundColor attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_BACKGROUND_COLOR } );
+
+		editor.model.schema.setAttributeProperties( FONT_BACKGROUND_COLOR, { isFormatting: true } );
 	}
 }

--- a/src/fontcolor/fontcolorediting.js
+++ b/src/fontcolor/fontcolorediting.js
@@ -117,5 +117,7 @@ export default class FontColorEditing extends Plugin {
 
 		// Allow fontColor attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_COLOR } );
+
+		editor.model.schema.setAttributeProperties( FONT_COLOR, { isFormatting: true } );
 	}
 }

--- a/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
+++ b/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
@@ -36,7 +36,7 @@ describe( 'FontBackgroundColorEditing', () => {
 		expect( editor.model.schema.checkAttribute( [ '$block' ], 'fontBackgroundColor' ) ).to.be.false;
 	} );
 
-	it( 'its attribute is marked with a formatting property', () => {
+	it( 'has the attribute marked with the isFormatting property', () => {
 		expect( editor.model.schema.getAttributeProperties( 'fontBackgroundColor' ) ).to.deep.equal( {
 			isFormatting: true
 		} );

--- a/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
+++ b/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
@@ -36,6 +36,12 @@ describe( 'FontBackgroundColorEditing', () => {
 		expect( editor.model.schema.checkAttribute( [ '$block' ], 'fontBackgroundColor' ) ).to.be.false;
 	} );
 
+	it( 'its attribute is marked with a formatting property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontBackgroundColor' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'config', () => {
 		describe( 'default value', () => {
 			it( 'should be set', () => {

--- a/tests/fontcolor/fontcolorediting.js
+++ b/tests/fontcolor/fontcolorediting.js
@@ -35,6 +35,12 @@ describe( 'FontColorEditing', () => {
 		expect( editor.model.schema.checkAttribute( [ '$block' ], 'fontColor' ) ).to.be.false;
 	} );
 
+	it( 'its attribute is marked with a formatting property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontColor' ) ).to.deep.equal( {
+			isFormatting: true
+		} );
+	} );
+
 	describe( 'config', () => {
 		describe( 'default value', () => {
 			it( 'should be set', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Marked font color and background color as formatting attribute using the isFormatting property. Closes ckeditor/ckeditor5#2287.