### PR TITLE
Update priorities in font plugin

### DIFF
--- a/src/fontfamily/utils.js
+++ b/src/fontfamily/utils.js
@@ -72,7 +72,7 @@ function generateFontPreset( fontDefinition ) {
 			styles: {
 				'font-family': cssFontNames
 			},
-			priority: 5
+			priority: 7
 		}
 	};
 }

--- a/src/fontsize/utils.js
+++ b/src/fontsize/utils.js
@@ -30,7 +30,7 @@ const namedPresets = {
 		view: {
 			name: 'span',
 			classes: 'text-tiny',
-			priority: 5
+			priority: 7
 		}
 	},
 	small: {
@@ -39,7 +39,7 @@ const namedPresets = {
 		view: {
 			name: 'span',
 			classes: 'text-small',
-			priority: 5
+			priority: 7
 		}
 	},
 	big: {
@@ -48,7 +48,7 @@ const namedPresets = {
 		view: {
 			name: 'span',
 			classes: 'text-big',
-			priority: 5
+			priority: 7
 		}
 	},
 	huge: {
@@ -57,7 +57,7 @@ const namedPresets = {
 		view: {
 			name: 'span',
 			classes: 'text-huge',
-			priority: 5
+			priority: 7
 		}
 	}
 };
@@ -113,7 +113,7 @@ function generatePixelPreset( size ) {
 			styles: {
 				'font-size': `${ size }px`
 			},
-			priority: 5
+			priority: 7
 		}
 	};
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,7 +84,7 @@ export function renderUpcastAttribute( styleAttr ) {
 export function renderDowncastElement( styleAttr ) {
 	return ( modelAttributeValue, viewWriter ) => viewWriter.createAttributeElement( 'span', {
 		style: `${ styleAttr }:${ modelAttributeValue }`
-	} );
+	}, { priority: 7 } );
 }
 
 /**
@@ -188,8 +188,7 @@ function normalizeSingleColorDefinition( color ) {
 				name: 'span',
 				styles: {
 					color
-				},
-				priority: 5
+				}
 			}
 		};
 	} else {
@@ -201,8 +200,7 @@ function normalizeSingleColorDefinition( color ) {
 				name: 'span',
 				styles: {
 					color: `${ color.color }`
-				},
-				priority: 5
+				}
 			}
 		};
 	}

--- a/tests/fontfamily/utils.js
+++ b/tests/fontfamily/utils.js
@@ -57,7 +57,7 @@ describe( 'FontFamily utils', () => {
 							styles: {
 								'font-family': 'Arial'
 							},
-							priority: 5
+							priority: 7
 						}
 					},
 					{
@@ -68,7 +68,7 @@ describe( 'FontFamily utils', () => {
 							styles: {
 								'font-family': '\'Comic Sans MS\', sans-serif'
 							},
-							priority: 5
+							priority: 7
 						}
 					},
 					{
@@ -79,7 +79,7 @@ describe( 'FontFamily utils', () => {
 							styles: {
 								'font-family': '\'Lucida Console\', \'Courier New\', Courier, monospace'
 							},
-							priority: 5
+							priority: 7
 						}
 					}
 				] );

--- a/tests/fontsize/fontsizeui.js
+++ b/tests/fontsize/fontsizeui.js
@@ -203,11 +203,11 @@ describe( 'FontSizeUI', () => {
 			it( 'does not alter normalizeOptions() internals', () => {
 				const options = normalizeOptions( [ 'tiny', 'small', 'default', 'big', 'huge' ] );
 				expect( options ).to.deep.equal( [
-					{ title: 'Tiny', model: 'tiny', view: { name: 'span', classes: 'text-tiny', priority: 5 } },
-					{ title: 'Small', model: 'small', view: { name: 'span', classes: 'text-small', priority: 5 } },
+					{ title: 'Tiny', model: 'tiny', view: { name: 'span', classes: 'text-tiny', priority: 7 } },
+					{ title: 'Small', model: 'small', view: { name: 'span', classes: 'text-small', priority: 7 } },
 					{ title: 'Default', model: undefined },
-					{ title: 'Big', model: 'big', view: { name: 'span', classes: 'text-big', priority: 5 } },
-					{ title: 'Huge', model: 'huge', view: { name: 'span', classes: 'text-huge', priority: 5 } }
+					{ title: 'Big', model: 'big', view: { name: 'span', classes: 'text-big', priority: 7 } },
+					{ title: 'Huge', model: 'huge', view: { name: 'span', classes: 'text-huge', priority: 7 } }
 				] );
 			} );
 

--- a/tests/fontsize/utils.js
+++ b/tests/fontsize/utils.js
@@ -28,11 +28,11 @@ describe( 'FontSizeEditing Utils', () => {
 		describe( 'named presets', () => {
 			it( 'should return defined presets', () => {
 				expect( normalizeOptions( [ 'tiny', 'small', 'default', 'big', 'huge' ] ) ).to.deep.equal( [
-					{ title: 'Tiny', model: 'tiny', view: { name: 'span', classes: 'text-tiny', priority: 5 } },
-					{ title: 'Small', model: 'small', view: { name: 'span', classes: 'text-small', priority: 5 } },
+					{ title: 'Tiny', model: 'tiny', view: { name: 'span', classes: 'text-tiny', priority: 7 } },
+					{ title: 'Small', model: 'small', view: { name: 'span', classes: 'text-small', priority: 7 } },
 					{ title: 'Default', model: undefined },
-					{ title: 'Big', model: 'big', view: { name: 'span', classes: 'text-big', priority: 5 } },
-					{ title: 'Huge', model: 'huge', view: { name: 'span', classes: 'text-huge', priority: 5 } }
+					{ title: 'Big', model: 'big', view: { name: 'span', classes: 'text-big', priority: 7 } },
+					{ title: 'Huge', model: 'huge', view: { name: 'span', classes: 'text-huge', priority: 7 } }
 				] );
 			} );
 		} );
@@ -40,11 +40,11 @@ describe( 'FontSizeEditing Utils', () => {
 		describe( 'numerical presets', () => {
 			it( 'should return generated presets', () => {
 				expect( normalizeOptions( [ '10', 12, 'default', '14.1', 18.3 ] ) ).to.deep.equal( [
-					{ title: '10', model: 10, view: { name: 'span', styles: { 'font-size': '10px' }, priority: 5 } },
-					{ title: '12', model: 12, view: { name: 'span', styles: { 'font-size': '12px' }, priority: 5 } },
+					{ title: '10', model: 10, view: { name: 'span', styles: { 'font-size': '10px' }, priority: 7 } },
+					{ title: '12', model: 12, view: { name: 'span', styles: { 'font-size': '12px' }, priority: 7 } },
 					{ title: 'Default', model: undefined },
-					{ title: '14.1', model: 14.1, view: { name: 'span', styles: { 'font-size': '14.1px' }, priority: 5 } },
-					{ title: '18.3', model: 18.3, view: { name: 'span', styles: { 'font-size': '18.3px' }, priority: 5 } }
+					{ title: '14.1', model: 14.1, view: { name: 'span', styles: { 'font-size': '14.1px' }, priority: 7 } },
+					{ title: '18.3', model: 18.3, view: { name: 'span', styles: { 'font-size': '18.3px' }, priority: 7 } }
 				] );
 			} );
 		} );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -9,6 +9,7 @@ import Font from '../src/font';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'Integration test Font', () => {
 	let element, editor, model;
@@ -41,15 +42,28 @@ describe( 'Integration test Font', () => {
 				'</paragraph>'
 			);
 
-			expect( editor.getData() ).to.equal(
-				'<p>' +
-					'<span ' +
-						'class="text-big" ' +
-						'style="font-family:Arial, Helvetica, sans-serif;background-color:rgb(10,20,30);color:#123456;"' +
-					'>foo' +
-					'</span>' +
-				'</p>'
-			);
+			if ( !env.isEdge ) {
+				expect( editor.getData() ).to.equal(
+					'<p>' +
+						'<span ' +
+							'class="text-big" ' +
+							'style="font-family:Arial, Helvetica, sans-serif;background-color:rgb(10,20,30);color:#123456;"' +
+						'>foo' +
+						'</span>' +
+					'</p>'
+				);
+			} else {
+				// Edge sorts attributes of an element.
+				expect( editor.getData() ).to.equal(
+					'<p>' +
+						'<span ' +
+							'class="text-big" ' +
+							'style="font-family:Arial, Helvetica, sans-serif;color:#123456;background-color:rgb(10,20,30);"' +
+						'>foo' +
+						'</span>' +
+					'</p>'
+				);
+			}
 		} );
 	} );
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,0 +1,75 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import Font from '../src/font';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+describe( 'Integration test Font', () => {
+	let element, editor, model;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, {
+				plugins: [ Font, ArticlePluginSet ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	describe( 'in-between font plugin features', () => {
+		it( 'should render one span element for all types of font features', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'<$text fontColor="#123456" fontBackgroundColor="rgb(10,20,30)" fontSize="big" fontFamily="Arial">foo</$text>' +
+				'</paragraph>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<p>' +
+					'<span ' +
+						'class="text-big" ' +
+						'style="font-family:Arial, Helvetica, sans-serif;background-color:rgb(10,20,30);color:#123456;"' +
+					'>foo' +
+					'</span>' +
+				'</p>'
+			);
+		} );
+	} );
+
+	describe( 'between font plugin and other', () => {
+		it( 'should render elements wrapped in proper order', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'<$text bold="true" linkHref="foo" fontColor="red" fontSize="big">foo</$text>' +
+				'</paragraph>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<p>' +
+					'<a href="foo">' +
+						'<span class="text-big" style="color:red;">' +
+							'<strong>foo</strong>' +
+						'</span>' +
+					'</a>' +
+				'</p>'
+			);
+		} );
+	} );
+} );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -49,8 +49,7 @@ describe( 'utils', () => {
 						name: 'span',
 						styles: {
 							color: 'black'
-						},
-						priority: 5
+						}
 					}
 				},
 				{
@@ -61,8 +60,7 @@ describe( 'utils', () => {
 						name: 'span',
 						styles: {
 							color: 'black'
-						},
-						priority: 5
+						}
 					}
 				},
 				{
@@ -73,8 +71,7 @@ describe( 'utils', () => {
 						name: 'span',
 						styles: {
 							color: 'black'
-						},
-						priority: 5
+						}
 					}
 				},
 				{
@@ -85,8 +82,7 @@ describe( 'utils', () => {
 						name: 'span',
 						styles: {
 							color: 'black'
-						},
-						priority: 5
+						}
 					}
 				},
 				{
@@ -97,8 +93,7 @@ describe( 'utils', () => {
 						name: 'span',
 						styles: {
 							color: 'black'
-						},
-						priority: 5
+						}
 					}
 				},
 			] );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -161,10 +161,11 @@ describe( 'utils', () => {
 	} );
 
 	it( 'renderDowncastElement()', () => {
-		const testRender = renderDowncastElement( 'color' );
+		const downcastViewConverterFn = renderDowncastElement( 'color' );
 		const fake = testUtils.sinon.fake();
+		const fakeViewWriter = { createAttributeElement: fake };
 
-		testRender( 'blue', { createAttributeElement: fake } );
+		downcastViewConverterFn( 'blue', fakeViewWriter );
 
 		sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
 	} );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -130,43 +130,48 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	it( 'addColorTableToDropdown()', () => {
-		const dropdown = createDropdown();
-		dropdown.render();
+	describe( 'addColorTableToDropdown()', () => {
+		it( 'should create dropdown with color table', () => {
+			const dropdown = createDropdown();
+			dropdown.render();
 
-		addColorTableToDropdown( {
-			dropdownView: dropdown,
-			colors: [
-				{
-					label: 'Black',
-					color: '#000',
-					options: {
-						hasBorder: false
+			addColorTableToDropdown( {
+				dropdownView: dropdown,
+				colors: [
+					{
+						label: 'Black',
+						color: '#000',
+						options: {
+							hasBorder: false
+						}
+					},
+					{
+						label: 'White',
+						color: '#FFFFFF',
+						options: {
+							hasBorder: true
+						}
 					}
-				},
-				{
-					label: 'White',
-					color: '#FFFFFF',
-					options: {
-						hasBorder: true
-					}
-				}
-			],
-			columns: 2,
-			removeButtonTooltip: 'Remove Color'
+				],
+				columns: 2,
+				removeButtonTooltip: 'Remove Color'
+			} );
+
+			expect( dropdown.colorTableView ).to.be.instanceOf( ColorTableView );
+			expect( dropdown.panelView.children.length ).to.equal( 1 );
+			expect( dropdown.colorTableView.element ).to.equal( dropdown.panelView.children.first.element );
 		} );
-
-		expect( dropdown.colorTableView ).to.be.instanceOf( ColorTableView );
-		expect( dropdown.panelView.children.length ).to.equal( 1 );
 	} );
 
-	it( 'renderDowncastElement()', () => {
-		const downcastViewConverterFn = renderDowncastElement( 'color' );
-		const fake = testUtils.sinon.fake();
-		const fakeViewWriter = { createAttributeElement: fake };
+	describe( 'renderDowncastElement()', () => {
+		it( 'should create function executes viewWriter with proper arguments', () => {
+			const downcastViewConverterFn = renderDowncastElement( 'color' );
+			const fake = testUtils.sinon.fake();
+			const fakeViewWriter = { createAttributeElement: fake };
 
-		downcastViewConverterFn( 'blue', fakeViewWriter );
+			downcastViewConverterFn( 'blue', fakeViewWriter );
 
-		sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
+			sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
+		} );
 	} );
 } );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -7,19 +7,23 @@ import {
 	FONT_COLOR,
 	FONT_BACKGROUND_COLOR,
 	normalizeColorOptions,
-	addColorTableToDropdown
+	addColorTableToDropdown,
+	renderDowncastElement
 } from './../src/utils';
 import { createDropdown } from '@ckeditor/ckeditor5-ui/src/dropdown/utils';
 import ColorTableView from './../src/ui/colortableview';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'utils', () => {
+	testUtils.createSinonSandbox();
+
 	describe( 'color and background color related', () => {
 		it( 'plugin names has proper values', () => {
 			expect( FONT_COLOR ).to.equal( 'fontColor' );
 			expect( FONT_BACKGROUND_COLOR ).to.equal( 'fontBackgroundColor' );
 		} );
 
-		it( 'normalizeColorOptions can produce the same output object', () => {
+		it( 'normalizeColorOptions() can produce the same output object', () => {
 			const normalizedArray = normalizeColorOptions( [
 				'black',
 				{
@@ -99,7 +103,7 @@ describe( 'utils', () => {
 			] );
 		} );
 
-		it( 'adding colors table to dropdown works', () => {
+		it( 'addColorTableToDropdown()', () => {
 			const dropdown = createDropdown();
 			dropdown.render();
 
@@ -127,6 +131,15 @@ describe( 'utils', () => {
 
 			expect( dropdown.colorTableView ).to.be.instanceOf( ColorTableView );
 			expect( dropdown.panelView.children.length ).to.equal( 1 );
+		} );
+
+		it( 'renderDowncastElement()', () => {
+			const testRender = renderDowncastElement( 'color' );
+			const fake = testUtils.sinon.fake();
+
+			testRender( 'blue', { createAttributeElement: fake } );
+
+			sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
 		} );
 	} );
 } );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -17,78 +17,104 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 describe( 'utils', () => {
 	testUtils.createSinonSandbox();
 
-	describe( 'color and background color related', () => {
-		it( 'plugin names has proper values', () => {
-			expect( FONT_COLOR ).to.equal( 'fontColor' );
-			expect( FONT_BACKGROUND_COLOR ).to.equal( 'fontBackgroundColor' );
+	it( 'plugin names has proper values', () => {
+		expect( FONT_COLOR ).to.equal( 'fontColor' );
+		expect( FONT_BACKGROUND_COLOR ).to.equal( 'fontBackgroundColor' );
+	} );
+
+	describe( 'normalizeColorOptions()', () => {
+		it( 'should return normalized config object from string', () => {
+			const normalizedOption = normalizeColorOptions( [ 'black' ] );
+
+			expect( normalizedOption ).to.deep.equal( [
+				{
+					model: 'black',
+					label: 'black',
+					hasBorder: false,
+					view: {
+						name: 'span',
+						styles: {
+							color: 'black'
+						}
+					}
+				}
+			] );
 		} );
 
-		it( 'normalizeColorOptions() can produce the same output object', () => {
-			const normalizedArray = normalizeColorOptions( [
-				'black',
+		it( 'should return normalized config object from object( color )', () => {
+			const normalizedOption = normalizeColorOptions( [ { color: 'black' } ] );
+
+			expect( normalizedOption ).to.deep.equal( [
 				{
-					color: 'black'
-				},
+					model: 'black',
+					label: 'black',
+					hasBorder: false,
+					view: {
+						name: 'span',
+						styles: {
+							color: 'black'
+						}
+					}
+				}
+			] );
+		} );
+
+		it( 'should return normalized config object from object( color, label )', () => {
+			const normalizedOption = normalizeColorOptions( [
 				{
 					color: 'black',
 					label: 'Black'
-				},
+				}
+			] );
+
+			expect( normalizedOption ).to.deep.equal( [
+				{
+					model: 'black',
+					label: 'Black',
+					hasBorder: false,
+					view: {
+						name: 'span',
+						styles: {
+							color: 'black'
+						}
+					}
+				}
+			] );
+		} );
+
+		it( 'should return normalized config object from object( color, label, hasBorder )', () => {
+			const normalizedOption = normalizeColorOptions( [
 				{
 					color: 'black',
 					label: 'Black',
 					hasBorder: true
-				},
+				}
+			] );
+
+			expect( normalizedOption ).to.deep.equal( [
+				{
+					model: 'black',
+					label: 'Black',
+					hasBorder: true,
+					view: {
+						name: 'span',
+						styles: {
+							color: 'black'
+						}
+					}
+				}
+			] );
+		} );
+
+		it( 'should return normalized config object from object( color, hasBorder )', () => {
+			const normalizedOption = normalizeColorOptions( [
 				{
 					color: 'black',
 					hasBorder: true
 				}
 			] );
 
-			expect( normalizedArray ).to.deep.equal( [
-				{
-					model: 'black',
-					label: 'black',
-					hasBorder: false,
-					view: {
-						name: 'span',
-						styles: {
-							color: 'black'
-						}
-					}
-				},
-				{
-					model: 'black',
-					label: 'black',
-					hasBorder: false,
-					view: {
-						name: 'span',
-						styles: {
-							color: 'black'
-						}
-					}
-				},
-				{
-					model: 'black',
-					label: 'Black',
-					hasBorder: false,
-					view: {
-						name: 'span',
-						styles: {
-							color: 'black'
-						}
-					}
-				},
-				{
-					model: 'black',
-					label: 'Black',
-					hasBorder: true,
-					view: {
-						name: 'span',
-						styles: {
-							color: 'black'
-						}
-					}
-				},
+			expect( normalizedOption ).to.deep.equal( [
 				{
 					model: 'black',
 					label: 'black',
@@ -99,47 +125,47 @@ describe( 'utils', () => {
 							color: 'black'
 						}
 					}
-				},
+				}
 			] );
 		} );
+	} );
 
-		it( 'addColorTableToDropdown()', () => {
-			const dropdown = createDropdown();
-			dropdown.render();
+	it( 'addColorTableToDropdown()', () => {
+		const dropdown = createDropdown();
+		dropdown.render();
 
-			addColorTableToDropdown( {
-				dropdownView: dropdown,
-				colors: [
-					{
-						label: 'Black',
-						color: '#000',
-						options: {
-							hasBorder: false
-						}
-					},
-					{
-						label: 'White',
-						color: '#FFFFFF',
-						options: {
-							hasBorder: true
-						}
+		addColorTableToDropdown( {
+			dropdownView: dropdown,
+			colors: [
+				{
+					label: 'Black',
+					color: '#000',
+					options: {
+						hasBorder: false
 					}
-				],
-				columns: 2,
-				removeButtonTooltip: 'Remove Color'
-			} );
-
-			expect( dropdown.colorTableView ).to.be.instanceOf( ColorTableView );
-			expect( dropdown.panelView.children.length ).to.equal( 1 );
+				},
+				{
+					label: 'White',
+					color: '#FFFFFF',
+					options: {
+						hasBorder: true
+					}
+				}
+			],
+			columns: 2,
+			removeButtonTooltip: 'Remove Color'
 		} );
 
-		it( 'renderDowncastElement()', () => {
-			const testRender = renderDowncastElement( 'color' );
-			const fake = testUtils.sinon.fake();
+		expect( dropdown.colorTableView ).to.be.instanceOf( ColorTableView );
+		expect( dropdown.panelView.children.length ).to.equal( 1 );
+	} );
 
-			testRender( 'blue', { createAttributeElement: fake } );
+	it( 'renderDowncastElement()', () => {
+		const testRender = renderDowncastElement( 'color' );
+		const fake = testUtils.sinon.fake();
 
-			sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
-		} );
+		testRender( 'blue', { createAttributeElement: fake } );
+
+		sinon.assert.calledWithExactly( fake, 'span', { style: 'color:blue' }, { priority: 7 } );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Update priorities in font plugin. Closes ckeditor/ckeditor5#2291.

---

### Additional information

* Priorities are set up to 7, to be higher than link (5), but lower than basic-styles (10). To have result that link remain most outer element and basic-styles elements will be always inside font features.
