### PR TITLE
Mark fonts' attributes with 'copyOnEnter' property

### DIFF
--- a/src/fontbackgroundcolor/fontbackgroundcolorediting.js
+++ b/src/fontbackgroundcolor/fontbackgroundcolorediting.js
@@ -118,6 +118,9 @@ export default class FontBackgroundColorEditing extends Plugin {
 		// Allow the font backgroundColor attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_BACKGROUND_COLOR } );
 
-		editor.model.schema.setAttributeProperties( FONT_BACKGROUND_COLOR, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( FONT_BACKGROUND_COLOR, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 	}
 }

--- a/src/fontcolor/fontcolorediting.js
+++ b/src/fontcolor/fontcolorediting.js
@@ -118,6 +118,9 @@ export default class FontColorEditing extends Plugin {
 		// Allow the font color attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_COLOR } );
 
-		editor.model.schema.setAttributeProperties( FONT_COLOR, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( FONT_COLOR, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 	}
 }

--- a/src/fontfamily/fontfamilyediting.js
+++ b/src/fontfamily/fontfamilyediting.js
@@ -54,7 +54,10 @@ export default class FontFamilyEditing extends Plugin {
 
 		// Allow fontFamily attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_FAMILY } );
-		editor.model.schema.setAttributeProperties( FONT_FAMILY, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( FONT_FAMILY, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 
 		// Get configured font family options without "default" option.
 		const options = normalizeOptions( editor.config.get( 'fontFamily.options' ) ).filter( item => item.model );

--- a/src/fontsize/fontsizeediting.js
+++ b/src/fontsize/fontsizeediting.js
@@ -63,6 +63,9 @@ export default class FontSizeEditing extends Plugin {
 
 		// Allow fontSize attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_SIZE } );
-		editor.model.schema.setAttributeProperties( FONT_SIZE, { isFormatting: true } );
+		editor.model.schema.setAttributeProperties( FONT_SIZE, {
+			isFormatting: true,
+			copyOnEnter: true
+		} );
 	}
 }

--- a/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
+++ b/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
@@ -37,8 +37,14 @@ describe( 'FontBackgroundColorEditing', () => {
 	} );
 
 	it( 'has the attribute marked with the isFormatting property', () => {
-		expect( editor.model.schema.getAttributeProperties( 'fontBackgroundColor' ) ).to.deep.equal( {
+		expect( editor.model.schema.getAttributeProperties( 'fontBackgroundColor' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontBackgroundColor' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/fontcolor/fontcolorediting.js
+++ b/tests/fontcolor/fontcolorediting.js
@@ -36,8 +36,14 @@ describe( 'FontColorEditing', () => {
 	} );
 
 	it( 'has the attribute marked with the isFormatting property', () => {
-		expect( editor.model.schema.getAttributeProperties( 'fontColor' ) ).to.deep.equal( {
+		expect( editor.model.schema.getAttributeProperties( 'fontColor' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontColor' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/fontfamily/fontfamilyediting.js
+++ b/tests/fontfamily/fontfamilyediting.js
@@ -37,8 +37,14 @@ describe( 'FontFamilyEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( editor.model.schema.getAttributeProperties( 'fontFamily' ) ).to.deep.equal( {
+		expect( editor.model.schema.getAttributeProperties( 'fontFamily' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontFamily' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 

--- a/tests/fontsize/fontsizeediting.js
+++ b/tests/fontsize/fontsizeediting.js
@@ -37,8 +37,14 @@ describe( 'FontSizeEditing', () => {
 	} );
 
 	it( 'should be marked with a formatting property', () => {
-		expect( editor.model.schema.getAttributeProperties( 'fontSize' ) ).to.deep.equal( {
+		expect( editor.model.schema.getAttributeProperties( 'fontSize' ) ).to.include( {
 			isFormatting: true
+		} );
+	} );
+
+	it( 'its attribute is marked with a copOnEnter property', () => {
+		expect( editor.model.schema.getAttributeProperties( 'fontSize' ) ).to.include( {
+			copyOnEnter: true
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Mark fonts' attributes with 'copyOnEnter' property.

---

### Additional information

* Requires: ckeditor/ckeditor5-enter#63