### PR TITLE
Lazy loading for the font color/bg dropdowns

### DIFF
--- a/src/ui/colortableview.js
+++ b/src/ui/colortableview.js
@@ -121,7 +121,7 @@ export default class ColorTableView extends View {
 		 * @readonly
 		 * @member {module:ui/colorgrid/colorgrid~ColorGridView}
 		 */
-		this.staticColorsGrid = this._createStaticColorsGrid();
+		this.staticColorsGrid;
 
 		/**
 		 * Preserves the reference to {@link module:ui/colorgrid/colorgrid~ColorGridView} used to create
@@ -164,14 +164,25 @@ export default class ColorTableView extends View {
 		} );
 
 		this.items.add( this._removeColorButton() );
+
+		this._documentColorsCount = documentColorsCount;
+		this._documentColorsLabel = documentColorsLabel;
+	}
+
+	renderGrids() {
+		if ( this.staticColorsGrid ) {
+			return;
+		}
+
+		this.staticColorsGrid = this._createStaticColorsGrid();
+
 		this.items.add( this.staticColorsGrid );
 
-		if ( documentColorsCount ) {
+		if ( this._documentColorsCount ) {
 			// Create a label for document colors.
 			const bind = Template.bind( this.documentColors, this.documentColors );
 			const label = new LabelView( this.locale );
-
-			label.text = documentColorsLabel;
+			label.text = this._documentColorsLabel;
 			label.extendTemplate( {
 				attributes: {
 					class: [
@@ -181,9 +192,7 @@ export default class ColorTableView extends View {
 					]
 				}
 			} );
-
 			this.items.add( label );
-
 			this.documentColorsGrid = this._createDocumentColorsGrid();
 			this.items.add( this.documentColorsGrid );
 		}

--- a/src/ui/colortableview.js
+++ b/src/ui/colortableview.js
@@ -118,19 +118,21 @@ export default class ColorTableView extends View {
 		 * Preserves the reference to {@link module:ui/colorgrid/colorgrid~ColorGridView} used to create
 		 * the default (static) color set.
 		 *
+		 * The property is loaded once the the parent dropdown is opened the first time.
+		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView/undefined}
 		 */
-		this.staticColorsGrid;
 
 		/**
 		 * Preserves the reference to {@link module:ui/colorgrid/colorgrid~ColorGridView} used to create
 		 * the document colors. It remains undefined if the document colors feature is disabled.
 		 *
+		 * The property is loaded once the the parent dropdown is opened the first time.
+		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView/undefined}
 		 */
-		this.documentColorsGrid;
 
 		/**
 		 * Helps cycling over focusable {@link #items} in the list.
@@ -152,6 +154,15 @@ export default class ColorTableView extends View {
 			}
 		} );
 
+		/**
+		 * Document color section's label.
+		 *
+		 * @private
+		 * @readonly
+		 * @type {String}
+		 */
+		this._documentColorsLabel = documentColorsLabel;
+
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {
@@ -164,38 +175,6 @@ export default class ColorTableView extends View {
 		} );
 
 		this.items.add( this._removeColorButton() );
-
-		this._documentColorsCount = documentColorsCount;
-		this._documentColorsLabel = documentColorsLabel;
-	}
-
-	renderGrids() {
-		if ( this.staticColorsGrid ) {
-			return;
-		}
-
-		this.staticColorsGrid = this._createStaticColorsGrid();
-
-		this.items.add( this.staticColorsGrid );
-
-		if ( this._documentColorsCount ) {
-			// Create a label for document colors.
-			const bind = Template.bind( this.documentColors, this.documentColors );
-			const label = new LabelView( this.locale );
-			label.text = this._documentColorsLabel;
-			label.extendTemplate( {
-				attributes: {
-					class: [
-						'ck',
-						'ck-color-grid__label',
-						bind.if( 'isEmpty', 'ck-hidden' )
-					]
-				}
-			} );
-			this.items.add( label );
-			this.documentColorsGrid = this._createDocumentColorsGrid();
-			this.items.add( this.documentColorsGrid );
-		}
 	}
 
 	/**
@@ -259,6 +238,38 @@ export default class ColorTableView extends View {
 
 		// Start listening for the keystrokes coming from #element.
 		this.keystrokes.listenTo( this.element );
+	}
+
+	/**
+	 * Renders and appends {@link #staticColorsGrid} and {@link #documentColorsGrid} views.
+	 */
+	renderGrids() {
+		if ( this.staticColorsGrid ) {
+			return;
+		}
+
+		this.staticColorsGrid = this._createStaticColorsGrid();
+
+		this.items.add( this.staticColorsGrid );
+
+		if ( this.documentColorsCount ) {
+			// Create a label for document colors.
+			const bind = Template.bind( this.documentColors, this.documentColors );
+			const label = new LabelView( this.locale );
+			label.text = this._documentColorsLabel;
+			label.extendTemplate( {
+				attributes: {
+					class: [
+						'ck',
+						'ck-color-grid__label',
+						bind.if( 'isEmpty', 'ck-hidden' )
+					]
+				}
+			} );
+			this.items.add( label );
+			this.documentColorsGrid = this._createDocumentColorsGrid();
+			this.items.add( this.documentColorsGrid );
+		}
 	}
 
 	/**

--- a/src/ui/colortableview.js
+++ b/src/ui/colortableview.js
@@ -121,7 +121,7 @@ export default class ColorTableView extends View {
 		 * The property is loaded once the the parent dropdown is opened the first time.
 		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined} staticColorsGrid
 		 */
 
 		/**
@@ -131,7 +131,7 @@ export default class ColorTableView extends View {
 		 * The property is loaded once the the parent dropdown is opened the first time.
 		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined} documentColorsGrid
 		 */
 
 		/**

--- a/src/ui/colortableview.js
+++ b/src/ui/colortableview.js
@@ -121,7 +121,7 @@ export default class ColorTableView extends View {
 		 * The property is loaded once the the parent dropdown is opened the first time.
 		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView/undefined}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined}
 		 */
 
 		/**
@@ -131,7 +131,7 @@ export default class ColorTableView extends View {
 		 * The property is loaded once the the parent dropdown is opened the first time.
 		 *
 		 * @readonly
-		 * @member {module:ui/colorgrid/colorgrid~ColorGridView/undefined}
+		 * @member {module:ui/colorgrid/colorgrid~ColorGridView|undefined}
 		 */
 
 		/**
@@ -241,9 +241,9 @@ export default class ColorTableView extends View {
 	}
 
 	/**
-	 * Renders and appends {@link #staticColorsGrid} and {@link #documentColorsGrid} views.
+	 * Appends {@link #staticColorsGrid} and {@link #documentColorsGrid} views.
 	 */
-	renderGrids() {
+	appendGrids() {
 		if ( this.staticColorsGrid ) {
 			return;
 		}

--- a/src/ui/colorui.js
+++ b/src/ui/colorui.js
@@ -132,6 +132,7 @@ export default class ColorUI extends Plugin {
 			} );
 
 			dropdownView.on( 'change:isOpen', ( evt, name, isVisible ) => {
+				// Grids rendering is deferred (#6192).
 				dropdownView.colorTableView.renderGrids();
 
 				if ( isVisible ) {

--- a/src/ui/colorui.js
+++ b/src/ui/colorui.js
@@ -132,6 +132,8 @@ export default class ColorUI extends Plugin {
 			} );
 
 			dropdownView.on( 'change:isOpen', ( evt, name, isVisible ) => {
+				dropdownView.colorTableView.renderGrids();
+
 				if ( isVisible ) {
 					if ( documentColorsCount !== 0 ) {
 						this.colorTableView.updateDocumentColors( editor.model, this.componentName );

--- a/src/ui/colorui.js
+++ b/src/ui/colorui.js
@@ -133,7 +133,7 @@ export default class ColorUI extends Plugin {
 
 			dropdownView.on( 'change:isOpen', ( evt, name, isVisible ) => {
 				// Grids rendering is deferred (#6192).
-				dropdownView.colorTableView.renderGrids();
+				dropdownView.colorTableView.appendGrids();
 
 				if ( isVisible ) {
 					if ( documentColorsCount !== 0 ) {

--- a/tests/ui/colortableview.js
+++ b/tests/ui/colortableview.js
@@ -79,7 +79,7 @@ describe( 'ColorTableView', () => {
 			documentColorsLabel: 'Document colors',
 			documentColorsCount: 4
 		} );
-		colorTableView.renderGrids();
+		colorTableView.appendGrids();
 		colorTableView.render();
 	} );
 
@@ -364,7 +364,7 @@ describe( 'ColorTableView', () => {
 					removeButtonLabel: 'Remove color',
 					documentColorsCount: 0
 				} );
-				colorTableView.renderGrids();
+				colorTableView.appendGrids();
 				colorTableView.render();
 			} );
 

--- a/tests/ui/colortableview.js
+++ b/tests/ui/colortableview.js
@@ -364,6 +364,7 @@ describe( 'ColorTableView', () => {
 					removeButtonLabel: 'Remove color',
 					documentColorsCount: 0
 				} );
+				colorTableView.renderGrids();
 				colorTableView.render();
 			} );
 
@@ -420,6 +421,7 @@ describe( 'ColorTableView', () => {
 
 					dropdown = editor.ui.componentFactory.create( 'testColor' );
 					dropdown.isOpen = true;
+					dropdown.isOpen = false;
 					dropdown.render();
 
 					staticColorsGrid = dropdown.colorTableView.staticColorsGrid;

--- a/tests/ui/colortableview.js
+++ b/tests/ui/colortableview.js
@@ -79,6 +79,7 @@ describe( 'ColorTableView', () => {
 			documentColorsLabel: 'Document colors',
 			documentColorsCount: 4
 		} );
+		colorTableView.renderGrids();
 		colorTableView.render();
 	} );
 
@@ -418,6 +419,7 @@ describe( 'ColorTableView', () => {
 					model = editor.model;
 
 					dropdown = editor.ui.componentFactory.create( 'testColor' );
+					dropdown.isOpen = true;
 					dropdown.render();
 
 					staticColorsGrid = dropdown.colorTableView.staticColorsGrid;

--- a/tests/ui/colorui.js
+++ b/tests/ui/colorui.js
@@ -7,6 +7,7 @@
 
 import TestColorPlugin from '../_utils/testcolorplugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import ColorGridView from '@ckeditor/ckeditor5-ui/src/colorgrid/colorgridview';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
@@ -151,6 +152,15 @@ describe( 'ColorUI', () => {
 			const colorTableView = dropdown.colorTableView;
 
 			expect( colorTableView.documentColorsCount ).to.equal( 3 );
+		} );
+
+		it( 'does not initialize grids when not open', () => {
+			const localDropdown = editor.ui.componentFactory.create( 'testColor' );
+			localDropdown.render();
+
+			for ( const item of localDropdown.colorTableView.items ) {
+				expect( item ).not.to.be.instanceOf( ColorGridView );
+			}
 		} );
 
 		describe( 'model to command binding', () => {

--- a/tests/ui/colorui.js
+++ b/tests/ui/colorui.js
@@ -116,6 +116,7 @@ describe( 'ColorUI', () => {
 		beforeEach( () => {
 			command = editor.commands.get( 'testColorCommand' );
 			dropdown = editor.ui.componentFactory.create( 'testColor' );
+			dropdown.isOpen = true;
 
 			dropdown.render();
 		} );
@@ -308,6 +309,7 @@ describe( 'ColorUI', () => {
 
 				colors.forEach( test => {
 					it( `tested color "${ test.color }" translated to "${ test.label }".`, () => {
+						dropdown.isOpen = true;
 						const colorGrid = dropdown.colorTableView.items.get( 1 );
 						const tile = colorGrid.items.find( colorTile => test.color === colorTile.color );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Implemented lazy loading for the font color and background dropdown. This will reduce editor initialization time. Closes ckeditor/ckeditor5#6192.

---

### Additional information

It's difficult to easily pull this optimization for the font color / bg plugin.

First of all this plugin [stores its model in the view](https://ckeditor.com/docs/ckeditor5/16.0.0/api/module_font_ui_colortableview-ColorTableView.html#member-documentColors) - so you need the view to have things running.

There's no clear UI and business logic separation for this plugin. For example, `ColorGridView` class (so type that we'd like to defer) [holds a selected color](https://github.com/ckeditor/ckeditor5-font/blob/c65579arc/colorgrid/colorgridview.js#L48).

It works, and the tests are passing - but the solution is not super pretty.