### PR TITLE
i/6636: Prefix font styles with the `.ck-content` class.

### DIFF
--- a/docs/features/font.md
+++ b/docs/features/font.md
@@ -94,19 +94,19 @@ The CSS definition for the classes (presets) must be included in the web page st
 Here is an example of the font size CSS classes:
 
 ```css
-.text-tiny {
+.ck-content .text-tiny {
 	font-size: 0.7em;
 }
 
-.text-small {
+.ck-content .text-small {
 	font-size: 0.85em;
 }
 
-.text-big {
+.ck-content .text-big {
 	font-size: 1.4em;
 }
 
-.text-huge {
+.ck-content .text-huge {
 	font-size: 1.8em;
 }
 ```

--- a/theme/fontsize.css
+++ b/theme/fontsize.css
@@ -4,18 +4,23 @@
  */
 
 /* The values should be synchronized with the "FONT_SIZE_PRESET_UNITS" object in the "/src/fontsize/utils.js" file. */
-.text-tiny {
-	font-size: .7em;
-}
 
-.text-small {
-	font-size: .85em;
-}
+/* Styles should be prefixed through the `.ck-content` class.
+See https://github.com/ckeditor/ckeditor5/issues/6636 */
+.ck-content {
+	& .text-tiny {
+		font-size: .7em;
+	}
 
-.text-big {
-	font-size: 1.4em;
-}
+	& .text-small {
+		font-size: .85em;
+	}
 
-.text-huge {
-	font-size: 1.8em;
+	& .text-big {
+		font-size: 1.4em;
+	}
+
+	& .text-huge {
+		font-size: 1.8em;
+	}
 }

--- a/theme/fontsize.css
+++ b/theme/fontsize.css
@@ -5,7 +5,7 @@
 
 /* The values should be synchronized with the "FONT_SIZE_PRESET_UNITS" object in the "/src/fontsize/utils.js" file. */
 
-/* Styles should be prefixed through the `.ck-content` class.
+/* Styles should be prefixed with the `.ck-content` class.
 See https://github.com/ckeditor/ckeditor5/issues/6636 */
 .ck-content {
 	& .text-tiny {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Font size styles should be prefixed by the `.ck-content` class. Closes ckeditor/ckeditor5#6636.
